### PR TITLE
Handle choice buttons without labels

### DIFF
--- a/game.js
+++ b/game.js
@@ -279,8 +279,17 @@ function presentEvent() {
 
   optionButtons.forEach((button, index) => {
     const choice = event.options[index];
-    button.disabled = false;
-    button.textContent = choice ? choice.label : "";
+    const hasChoice = Boolean(choice);
+
+    button.disabled = !hasChoice;
+    button.textContent = hasChoice ? choice.label : "";
+    button.classList.toggle("option-button--hidden", !hasChoice);
+
+    if (hasChoice) {
+      button.removeAttribute("aria-hidden");
+    } else {
+      button.setAttribute("aria-hidden", "true");
+    }
   });
 
   if (event.signal) {

--- a/style.css
+++ b/style.css
@@ -155,6 +155,10 @@ h1 {
   cursor: not-allowed;
 }
 
+.option-button.option-button--hidden {
+  display: none;
+}
+
 .option-button:hover,
 .option-button:focus-visible,
 .ghost-button:hover,


### PR DESCRIPTION
## Summary
- ensure option buttons with no corresponding choice are hidden and marked aria-hidden so players never see blank actions
- add CSS helper to remove empty buttons from the grid layout

## Testing
- node --check game.js

------
https://chatgpt.com/codex/tasks/task_e_68d9905424ec832f9acba49084a74686